### PR TITLE
base/week5

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,45 +1,34 @@
-### 상품 조회 성능 최적화: 인덱스 추가 및 EXPLAIN 전/후 성능 비교
+## 📌 Summary
+<!--
+    어떤 기능/이슈를 해결했는지 요약해주세요.
+-->
 
-## 1) 인덱스 설계
+## 💬 Review Points
+<!--
+    리뷰어가 더 효과적인 리뷰를 할 수 있도록 도와주는 부분입니다.
+    (1) 리뷰어가 중점적으로 봐줬으면 하는 부분
+    (2) 고민했던 설계 포인트나 로직
+    (3) 리뷰어가 확인해줬으면 하는 테스트 케이스나 예외 상황
+    (4) 기타 리뷰어가 참고해야 할 사항
+-->
 
-```sql
--- UseCase1: 브랜드 + 카테고리 + 좋아요순 + 최신순
-CREATE INDEX idx_brand_category_like_id
-  ON products (brand_id, product_category, like_count DESC, id DESC);
+## ✅ Checklist
+<!--
+    해당 작업이 완료되었는지 확인하기 위한 체크리스트입니다.
+    리뷰어가 확인해야 할 사항을 포함합니다.
+    계획중이나 아직 완료되지 않은 작업 또한 `TODO -` 로 작성해주세요.  
 
--- UseCase2: 브랜드 + 카테고리 + 가격순 + 최신순
-CREATE INDEX idx_brand_category_price_id
-  ON products (brand_id, product_category, basic_price ASC, id DESC);
+    ex.
+    - [ ] 테스트 코드 포함
+    - [ ] 불필요한 코드 제거
+    - [ ] README or 주석 보강 (필요 시)
+-->
 
--- UseCase3: 브랜드 + 좋아요순 + 최신순
-CREATE INDEX idx_brand_like_id
-  ON products (brand_id, like_count DESC, id DESC);
-
--- UseCase4: 브랜드 + 가격순 + 최신순
-CREATE INDEX idx_brand_price_id
-  ON products (brand_id, basic_price ASC, id DESC);
-```
-
-## 2) 유즈케이스별 쿼리 & 성능 비교
-
-| UC  | 쿼리 | Before – key / rows / Extra | After – key / rows / Extra | 개선 포인트 |
-|---|---|---|---|---|
-| UC1 | `WHERE brand_id = ? AND product_category = 'CLOTHING' ORDER BY like_count DESC, id DESC LIMIT 20` | `idx_brand_price_id` / 200 / `Using where; Using filesort` | `idx_brand_like_id` / 200 / `Using where` | Filesort 제거 → 인덱스 순차 스캔 활용 |
-| UC2 | `WHERE brand_id = ? AND product_category = 'CLOTHING' ORDER BY basic_price, id DESC LIMIT 20` | `idx_brand_price_id` / 200 / `Using where; Using filesort` | `idx_brand_price_id` / 200 / `Using where` | Filesort 제거 |
-| UC3 | `WHERE brand_id = ? ORDER BY like_count DESC, id DESC LIMIT 20` | `idx_brand_price_id` / 200 / `Using filesort` | `idx_brand_like_id` / 200 / *(null)* | Filesort 제거, 순차 인덱스 스캔 |
-| UC4 | `WHERE brand_id = ? ORDER BY basic_price, id DESC LIMIT 20` | `idx_brand_price_id` / 200 / `Using filesort` | `idx_brand_price_id` / 200 / *(null)* | Filesort 제거, 순차 인덱스 스캔 |
-
-
-## 3) k6 성능 결과 (Before → After)
-
-| Metric (Scenario) | Before Avg | After Avg | Before p(95) | After p(95) | Change Avg | Change p(95) |
-|-------------------|-----------:|----------:|-------------:|------------:|-----------:|-------------:|
-| UC1 Duration      | 16.5883 ms | 16.4664 ms | 25.2784 ms | 24.9821 ms | **-0.1219 ms** | **-0.2963 ms** |
-| UC2 Duration      | 16.4360 ms | 16.2733 ms | 26.2548 ms | 24.4146 ms | **-0.1627 ms** | **-1.8402 ms** |
-| UC3 Duration      | 16.5549 ms | 16.4149 ms | 26.1010 ms | 25.2722 ms | **-0.1399 ms** | **-0.8288 ms** |
-| UC4 Duration      | 16.0937 ms | 16.4854 ms | 25.8263 ms | 25.1156 ms | **+0.3918 ms** | **-0.7108 ms** |
-| 전체 HTTP Req     | 16.4182 ms | 16.4100 ms | 25.9909 ms | 25.0012 ms | **-0.0082 ms** | **-0.9897 ms** |
-
-## 4) 개선 요약
-- UC1/UC3: `brand_id, like_count DESC, id DESC` 복합 인덱스로 **정렬 시 Filesort 제거** → 인덱스 순차 스캔.
-- UC2/UC4: `brand_id, basic_price ASC, id DESC`로 **가격 정렬 최적화** → Filesort 제거.
+## 📎 References
+<!--
+  (Optional: 참고 자료가 없는 작업 - 단순 버그 픽스 등 의 경우엔 해당 란을 제거해주세요 !)
+  리뷰어가 참고할 수 있는 추가적인 정보나 문서, 링크 등을 작성해주세요.
+  예시:
+  - 관련 문서 링크
+  - 관련 정책 링크
+-->

--- a/apps/commerce-api/build.gradle.kts
+++ b/apps/commerce-api/build.gradle.kts
@@ -1,6 +1,7 @@
 dependencies {
     // add-ons
     implementation(project(":modules:jpa"))
+    implementation(project(":modules:redis"))
     implementation(project(":supports:jackson"))
     implementation(project(":supports:logging"))
     implementation(project(":supports:monitoring"))

--- a/apps/commerce-api/build.gradle.kts
+++ b/apps/commerce-api/build.gradle.kts
@@ -18,6 +18,7 @@ dependencies {
 
     // test-fixtures
     testImplementation(testFixtures(project(":modules:jpa")))
+    testImplementation(testFixtures(project(":modules:redis")))
 
     implementation("org.springframework.boot:spring-boot-starter-aop")
 

--- a/apps/commerce-api/src/main/java/com/loopers/application/product/ProductCacheRefresher.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/product/ProductCacheRefresher.java
@@ -1,0 +1,41 @@
+package com.loopers.application.product;
+
+import com.loopers.domain.product.Product;
+import com.loopers.domain.product.ProductCache;
+import com.loopers.domain.product.ProductChangedEvent;
+import com.loopers.domain.product.ProductRepository;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class ProductCacheRefresher {
+    private final ProductCache productCache;
+    private final ProductRepository productRepository;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Transactional(readOnly = true, propagation = Propagation.REQUIRES_NEW)
+    public void onProductChanged(ProductChangedEvent event) {
+        Long productId = event.productId();
+        try {
+            productCache.evict(productId);
+
+            Product p = productRepository.findWithBrandById(productId)
+                    .orElseThrow(() -> new CoreException(
+                            ErrorType.PRODUCT_NOT_FOUND, "존재하지 않는 상품입니다. id=" + productId));
+
+            productCache.put(productId, p, productCache.ttl());
+            log.info("[ProductCacheRefresher] refreshed cache for productId={}", productId);
+        } catch (Exception e) {
+            log.warn("[ProductCacheRefresher] failed to refresh product cache. productId={}", productId, e);
+        }
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/product/ProductOptionCacheRefresher.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/product/ProductOptionCacheRefresher.java
@@ -1,0 +1,39 @@
+package com.loopers.application.product;
+
+import com.loopers.domain.product.ProductChangedEvent;
+import com.loopers.domain.product.ProductOption;
+import com.loopers.domain.product.ProductOptionCache;
+import com.loopers.domain.product.ProductOptionRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import java.util.List;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class ProductOptionCacheRefresher {
+    private final ProductOptionCache productOptionCache;
+    private final ProductOptionRepository productOptionRepository;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Transactional(readOnly = true, propagation = Propagation.REQUIRES_NEW)
+    public void onProductChanged(ProductChangedEvent event) {
+        Long productId = event.productId();
+        try {
+            productOptionCache.evict(productId);
+
+            List<ProductOption> productOptions = productOptionRepository.findByProductId(productId);
+
+            productOptionCache.put(productId, productOptions, productOptionCache.ttl());
+            log.info("[ProductOptionCacheRefresher] refreshed cache for productId={}", productId);
+        } catch (Exception e) {
+            log.warn("[ProductOptionCacheRefresher] failed to refresh product option cache. productId={}", productId, e);
+        }
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/Product.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/Product.java
@@ -11,7 +11,13 @@ import java.math.BigDecimal;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "products")
+@Table(name = "products",
+        indexes = {
+                @Index(name = "idx_brand_like_id", columnList = "brand_id, like_count DESC, id DESC"),
+                @Index(name = "idx_brand_price_id", columnList = "brand_id, basic_price ASC, id DESC"),
+                @Index(name = "idx_brand_category_like_id", columnList = "brand_id, product_category, like_count DESC, id DESC"),
+                @Index(name = "idx_brand_category_price_id", columnList = "brand_id, product_category, basic_price ASC, id DESC")
+        })
 @Entity
 public class Product extends BaseEntity {
 

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductCache.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductCache.java
@@ -13,6 +13,10 @@ public interface ProductCache {
         return "product:v1:" + productId;
     }
 
+    default void put(Long productId, Product product, Duration ttl) {
+        delegate().put(key(productId), product, ttl);
+    }
+
     default Product getOrLoad(Long productId, Callable<Product> loader) {
         return delegate().getOrLoad(
                 key(productId),
@@ -20,5 +24,9 @@ public interface ProductCache {
                 new TypeReference<Product>() {},
                 loader
         );
+    }
+
+    default void evict(Long productId) {
+        delegate().evict(key(productId));
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductCache.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductCache.java
@@ -1,0 +1,24 @@
+package com.loopers.domain.product;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.loopers.infrastructure.cache.GenericCachePort;
+
+import java.time.Duration;
+import java.util.concurrent.Callable;
+
+public interface ProductCache {
+    GenericCachePort delegate();
+    Duration ttl();
+    default String key(Long productId) {
+        return "product:v1:" + productId;
+    }
+
+    default Product getOrLoad(Long productId, Callable<Product> loader) {
+        return delegate().getOrLoad(
+                key(productId),
+                ttl(),
+                new TypeReference<Product>() {},
+                loader
+        );
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductChangedEvent.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductChangedEvent.java
@@ -1,0 +1,6 @@
+package com.loopers.domain.product;
+
+public record ProductChangedEvent(
+        Long productId
+) {
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductCriteria.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductCriteria.java
@@ -27,4 +27,8 @@ public record ProductCriteria(
             sortBy
         );
     }
+
+    public boolean isDefault() {
+        return keyword == null && category == null && brandId == null && sort == null;
+    }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductListCache.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductListCache.java
@@ -1,0 +1,26 @@
+package com.loopers.domain.product;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.loopers.infrastructure.cache.GenericCachePort;
+import org.springframework.data.domain.Page;
+
+import java.time.Duration;
+import java.util.concurrent.Callable;
+
+public interface ProductListCache {
+    GenericCachePort delegate();
+    Duration ttl();
+
+    default String listKey(int page) {
+        return "product:list:v1:page:" + page;
+    }
+
+    default Page<Product> getOrLoad(int page, Callable<Page<Product>> loader) {
+        return delegate().getOrLoad(
+                listKey(page),
+                ttl(),
+                new TypeReference<Page<Product>>() {},
+                loader
+        );
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductListCache.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductListCache.java
@@ -3,6 +3,8 @@ package com.loopers.domain.product;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.loopers.infrastructure.cache.GenericCachePort;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 
 import java.time.Duration;
 import java.util.concurrent.Callable;
@@ -15,12 +17,15 @@ public interface ProductListCache {
         return "product:list:v1:page:" + page;
     }
 
-    default Page<Product> getOrLoad(int page, Callable<Page<Product>> loader) {
+    default Page<Product> getOrLoad(Pageable pageable, Callable<Page<Product>> loader) {
         return delegate().getOrLoad(
-                listKey(page),
+                listKey(pageable.getPageNumber()),
                 ttl(),
-                new TypeReference<Page<Product>>() {},
-                loader
+                new TypeReference<PageImpl<Product>>() {},
+                () -> {
+                    Page<Product> p = loader.call();
+                    return new PageImpl<>(p.getContent(), pageable, p.getTotalElements());
+                }
         );
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductOption.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductOption.java
@@ -3,10 +3,7 @@ package com.loopers.domain.product;
 import com.loopers.domain.BaseEntity;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
-import jakarta.persistence.Entity;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -22,6 +19,8 @@ public class ProductOption extends BaseEntity {
     private String name;
     private String size;
     private String color;
+
+    @Enumerated(EnumType.STRING)
     private ProductStatus productOptionStatus;
     private BigDecimal price;
 

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductOptionCache.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductOptionCache.java
@@ -25,4 +25,12 @@ public interface ProductOptionCache {
                 loader
         );
     }
+
+    default void evict(Long productId) {
+        delegate().evict(key(productId));
+    };
+
+    default void put(Long productId, List<ProductOption> productOptions, Duration ttl) {
+        delegate().put(key(productId), productOptions, ttl);
+    }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductOptionCache.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductOptionCache.java
@@ -1,0 +1,28 @@
+package com.loopers.domain.product;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.loopers.infrastructure.cache.GenericCachePort;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.Callable;
+
+public interface ProductOptionCache {
+    GenericCachePort delegate();
+    Duration ttl();
+    default String key(Long productId) {
+        return "product:option:v1:" + productId;
+    }
+
+    default List<ProductOption> getOrLoad(
+            Long productId,
+            Callable<List<ProductOption>> loader
+    ) {
+        return delegate().getOrLoad(
+                key(productId),
+                ttl(),
+                new TypeReference<List<ProductOption>>() {},
+                loader
+        );
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductOptionChangedEvent.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductOptionChangedEvent.java
@@ -1,0 +1,6 @@
+package com.loopers.domain.product;
+
+public record ProductOptionChangedEvent(
+        Long productId
+) {
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductOptionService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductOptionService.java
@@ -11,16 +11,18 @@ import java.util.List;
 @RequiredArgsConstructor
 @Service
 public class ProductOptionService {
-
     private final ProductOptionRepository productOptionRepository;
+    private final ProductOptionCache productOptionCache;
 
     @Transactional(readOnly = true)
     public List<ProductOption> getProductOptionsByProductId(Long productId) {
-        List<ProductOption> productOptions = productOptionRepository.findByProductId(productId);
-        if (productOptions.isEmpty()) {
+        List<ProductOption> cached = productOptionCache.getOrLoad(productId,
+                () -> productOptionRepository.findByProductId(productId)
+        );
+        if (cached.isEmpty()) {
             throw new CoreException(ErrorType.PRODUCT_OPTION_NOT_FOUND, "상품을 찾을 수 없습니다. product id:" + productId);
         }
-        return productOptions;
+        return cached;
     }
 
     public ProductOption getOnSalesProductOption(Long productOptionId) {

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductPotionCacheImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductPotionCacheImpl.java
@@ -1,0 +1,24 @@
+package com.loopers.domain.product;
+
+import com.loopers.infrastructure.cache.GenericCachePort;
+import com.loopers.infrastructure.cache.RedisGenericCachePort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.time.Duration;
+
+@RequiredArgsConstructor
+@Repository
+public class ProductPotionCacheImpl implements ProductOptionCache {
+    private final RedisGenericCachePort delegate;
+
+    @Override
+    public GenericCachePort delegate() {
+        return delegate;
+    }
+
+    @Override
+    public Duration ttl() {
+        return Duration.ofMinutes(5);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductService.java
@@ -14,8 +14,8 @@ import java.util.List;
 @RequiredArgsConstructor
 @Service
 public class ProductService {
-
     private final ProductRepository productRepository;
+    private final ProductCache productCache;
 
     @Transactional(readOnly = true)
     public Page<Product> searchByConditionWithPaging(ProductCriteria criteria, Pageable pageable) {
@@ -24,8 +24,8 @@ public class ProductService {
 
     @Transactional(readOnly = true)
     public Product getProductWithBrandById(Long productId) {
-        return productRepository.findWithBrandById(productId)
-                .orElseThrow(() -> new CoreException(ErrorType.PRODUCT_NOT_FOUND, "존재하지 않는 상품 id: " + productId));
+        return productCache.getOrLoad(productId, () -> productRepository.findWithBrandById(productId)
+                .orElseThrow(() -> new CoreException(ErrorType.PRODUCT_NOT_FOUND, "존재하지 않는 상품 id: " + productId)));
     }
 
     public List<Product> getProductByBrand(Brand brand) {

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductService.java
@@ -25,7 +25,7 @@ public class ProductService {
         boolean isCacheablePage = page >= 0 && page <= 2;
 
         if (isDefaultFilter && isCacheablePage) {
-            return productListCache.getOrLoad(page, () -> productRepository.findAllByCriteria(criteria, pageable));
+            return productListCache.getOrLoad(pageable, () -> productRepository.findAllByCriteria(criteria, pageable));
         }
 
         return productRepository.findAllByCriteria(criteria, pageable);

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductService.java
@@ -16,9 +16,18 @@ import java.util.List;
 public class ProductService {
     private final ProductRepository productRepository;
     private final ProductCache productCache;
+    private final ProductListCache productListCache;
 
     @Transactional(readOnly = true)
     public Page<Product> searchByConditionWithPaging(ProductCriteria criteria, Pageable pageable) {
+        int page = pageable.getPageNumber();
+        boolean isDefaultFilter = criteria.isDefault();
+        boolean isCacheablePage = page >= 0 && page <= 2;
+
+        if (isDefaultFilter && isCacheablePage) {
+            return productListCache.getOrLoad(page, () -> productRepository.findAllByCriteria(criteria, pageable));
+        }
+
         return productRepository.findAllByCriteria(criteria, pageable);
     }
 

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/like/ProductLikeService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/like/ProductLikeService.java
@@ -1,6 +1,7 @@
 package com.loopers.domain.product.like;
 
 import com.loopers.domain.product.Product;
+import com.loopers.domain.product.ProductChangedEvent;
 import com.loopers.domain.user.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
@@ -25,8 +26,8 @@ public class ProductLikeService {
         if (!alreadyLiked) {
             productLikeRepository.save(ProductLike.create(product, user));
             product.increaseLikeCount();
+            publisher.publishEvent(new ProductChangedEvent(product.getId()));
         }
-
     }
 
     @Transactional
@@ -35,6 +36,7 @@ public class ProductLikeService {
         if (alreadyLiked) {
             productLikeRepository.deleteByProductAndUser(product, user);
             product.decreaseLikeCount();
+            publisher.publishEvent(new ProductChangedEvent(product.getId()));
         }
     }
 

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/like/ProductLikeService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/like/ProductLikeService.java
@@ -3,6 +3,7 @@ package com.loopers.domain.product.like;
 import com.loopers.domain.product.Product;
 import com.loopers.domain.user.User;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -12,6 +13,7 @@ import java.util.List;
 @Service
 public class ProductLikeService {
     private final ProductLikeRepository productLikeRepository;
+    private final ApplicationEventPublisher publisher;
 
     public boolean existsByProductAndUser(Product product, User user) {
         return productLikeRepository.existsByProductAndUser(product, user);
@@ -24,6 +26,7 @@ public class ProductLikeService {
             productLikeRepository.save(ProductLike.create(product, user));
             product.increaseLikeCount();
         }
+
     }
 
     @Transactional

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/cache/GenericCachePort.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/cache/GenericCachePort.java
@@ -1,0 +1,15 @@
+package com.loopers.infrastructure.cache;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+
+import java.time.Duration;
+import java.util.concurrent.Callable;
+
+public interface GenericCachePort {
+    <T> T get(String key, TypeReference<T> typeRef);
+
+    <T> void put(String key, T value, Duration ttl);
+
+    void evict(String key);
+
+    <T> T getOrLoad(String key, Duration ttl, TypeReference<T> typeRef, Callable<T> loader);}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/cache/RedisGenericCachePort.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/cache/RedisGenericCachePort.java
@@ -9,7 +9,11 @@ import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
+import java.lang.reflect.Array;
 import java.time.Duration;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
@@ -69,7 +73,7 @@ public class RedisGenericCachePort implements GenericCachePort {
                 }
             }
 
-            // 2) 로더 실행
+            // 로더 실행
             T loaded = loader.call();
 
             // 빈 결과는 '캐시하지 않음'
@@ -95,17 +99,17 @@ public class RedisGenericCachePort implements GenericCachePort {
             case CharSequence s -> {
                 return s.isEmpty();
             }
-            case java.util.Collection<?> c -> {
+            case Collection<?> c -> {
                 return c.isEmpty();
             }
-            case java.util.Map<?, ?> m -> {
+            case Map<?, ?> m -> {
                 return m.isEmpty();
             }
             default -> {
             }
         }
-        if (v.getClass().isArray()) return java.lang.reflect.Array.getLength(v) == 0;
-        if (v instanceof java.util.Optional<?> o) return o.isEmpty();
+        if (v.getClass().isArray()) return Array.getLength(v) == 0;
+        if (v instanceof Optional<?> o) return o.isEmpty();
         return false;
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/cache/RedisGenericCachePort.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/cache/RedisGenericCachePort.java
@@ -5,6 +5,8 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.loopers.support.error.CoreException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Component;
 
@@ -93,23 +95,19 @@ public class RedisGenericCachePort implements GenericCachePort {
 
     private boolean isEmptyValue(Object v) {
         switch (v) {
-            case null -> {
-                return true;
-            }
-            case CharSequence s -> {
-                return s.isEmpty();
-            }
-            case Collection<?> c -> {
-                return c.isEmpty();
-            }
-            case Map<?, ?> m -> {
-                return m.isEmpty();
-            }
-            default -> {
-            }
+            case null -> { return true; }
+            case CharSequence s -> { return s.isEmpty(); }
+            case Collection<?> c -> { return c.isEmpty(); }
+            case Map<?, ?> m -> { return m.isEmpty(); }
+            case Page<?> p -> { return p.isEmpty(); }
+            case Slice<?> s -> { return !s.hasContent(); }
+            default -> { /* fall-through */ }
         }
         if (v.getClass().isArray()) return Array.getLength(v) == 0;
         if (v instanceof Optional<?> o) return o.isEmpty();
+        if (v instanceof Iterable<?> it) {
+            return !it.iterator().hasNext();
+        }
         return false;
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/cache/RedisGenericCachePort.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/cache/RedisGenericCachePort.java
@@ -1,0 +1,72 @@
+package com.loopers.infrastructure.cache;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.loopers.support.error.CoreException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+
+@Component
+@RequiredArgsConstructor
+public class RedisGenericCachePort implements GenericCachePort {
+
+    private final StringRedisTemplate redis;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public <T> T get(String key, TypeReference<T> typeRef) {
+        String json = redis.opsForValue().get(key);
+        if (json == null) return null;
+        try {
+            return objectMapper.readValue(json, typeRef);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public <T> void put(String key, T value, Duration ttl) {
+        try {
+            String json = objectMapper.writeValueAsString(value);
+            redis.opsForValue().set(key, json, ttl.toMillis(), TimeUnit.MILLISECONDS);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void evict(String key) {
+        redis.delete(key);
+    }
+
+    @Override
+    public <T> T getOrLoad(String key, Duration ttl, TypeReference<T> typeRef, Callable<T> loader) {
+        T cached = get(key, typeRef);
+        if (cached != null) return cached;
+
+        String lockKey = "lock:" + key;
+        boolean acquired = Boolean.TRUE.equals(redis.opsForValue().setIfAbsent(lockKey, "1", 5, TimeUnit.SECONDS));
+
+        try {
+            if (!acquired) {
+                Thread.sleep(50);
+                T again = get(key, typeRef);
+                if (again != null) return again;
+            }
+            T loaded = loader.call();
+            if (loaded != null) put(key, loaded, ttl);
+            return loaded;
+        } catch (Exception e) {
+            throw new CoreException(((CoreException) e).getErrorType(), e.getMessage());
+        } finally {
+            if (acquired) redis.delete(lockKey);
+        }
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/cache/RedisGenericCachePort.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/cache/RedisGenericCachePort.java
@@ -48,25 +48,64 @@ public class RedisGenericCachePort implements GenericCachePort {
 
     @Override
     public <T> T getOrLoad(String key, Duration ttl, TypeReference<T> typeRef, Callable<T> loader) {
+        // 1) 캐시 조회: null 이거나 '빈 값'이면 미스로 처리
         T cached = get(key, typeRef);
-        if (cached != null) return cached;
+        if (cached != null && !isEmptyValue(cached)) {
+            return cached;
+        }
 
         String lockKey = "lock:" + key;
-        boolean acquired = Boolean.TRUE.equals(redis.opsForValue().setIfAbsent(lockKey, "1", 5, TimeUnit.SECONDS));
+        boolean acquired = Boolean.TRUE.equals(
+                redis.opsForValue().setIfAbsent(lockKey, "1", 5, TimeUnit.SECONDS)
+        );
 
         try {
+            // 락을 못잡았으면 잠깐 대기 후 다시 확인
             if (!acquired) {
-                Thread.sleep(50);
+                try { Thread.sleep(50); } catch (InterruptedException ignored) {}
                 T again = get(key, typeRef);
-                if (again != null) return again;
+                if (again != null && !isEmptyValue(again)) {
+                    return again;
+                }
             }
+
+            // 2) 로더 실행
             T loaded = loader.call();
-            if (loaded != null) put(key, loaded, ttl);
+
+            // 빈 결과는 '캐시하지 않음'
+            if (loaded != null && !isEmptyValue(loaded)) {
+                put(key, loaded, ttl);
+            }
+
             return loaded;
         } catch (Exception e) {
-            throw new CoreException(((CoreException) e).getErrorType(), e.getMessage());
+            // CoreException만 그대로 통과, 나머지는 래핑
+            if (e instanceof CoreException ce) throw ce;
+            throw new RuntimeException("cache loader failed: " + e.getMessage(), e);
         } finally {
             if (acquired) redis.delete(lockKey);
         }
+    }
+
+    private boolean isEmptyValue(Object v) {
+        switch (v) {
+            case null -> {
+                return true;
+            }
+            case CharSequence s -> {
+                return s.isEmpty();
+            }
+            case java.util.Collection<?> c -> {
+                return c.isEmpty();
+            }
+            case java.util.Map<?, ?> m -> {
+                return m.isEmpty();
+            }
+            default -> {
+            }
+        }
+        if (v.getClass().isArray()) return java.lang.reflect.Array.getLength(v) == 0;
+        if (v instanceof java.util.Optional<?> o) return o.isEmpty();
+        return false;
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductCacheImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductCacheImpl.java
@@ -1,0 +1,25 @@
+package com.loopers.infrastructure.product;
+
+import com.loopers.domain.product.ProductCache;
+import com.loopers.infrastructure.cache.GenericCachePort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.time.Duration;
+
+@RequiredArgsConstructor
+@Repository
+public class ProductCacheImpl implements ProductCache {
+    private final GenericCachePort delegate;
+
+    @Override
+    public GenericCachePort delegate() {
+        return delegate;
+    }
+
+    @Override
+    public Duration ttl() {
+        return Duration.ofMinutes(5);
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductListCacheImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductListCacheImpl.java
@@ -1,0 +1,24 @@
+package com.loopers.infrastructure.product;
+
+import com.loopers.domain.product.ProductListCache;
+import com.loopers.infrastructure.cache.GenericCachePort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+
+@RequiredArgsConstructor
+@Component
+public class ProductListCacheImpl implements ProductListCache {
+    private final GenericCachePort delegate;
+
+    @Override
+    public GenericCachePort delegate() {
+        return delegate;
+    }
+
+    @Override
+    public Duration ttl() {
+        return Duration.ofMinutes(10);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1Controller.java
@@ -33,6 +33,8 @@ public class ProductV1Controller {
     @GetMapping("/{productId}")
     public ApiResponse<ProductDetailResponse> getProductDetail(@PathVariable Long productId, @CurrentUser UserInfo userInfo) {
         ProductInfo productInfo = productFacade.getProductDetail(productId, userInfo);
+        ProductDetailResponse from = ProductDetailResponse.from(productInfo);
+        System.out.println("from = " + from);
         return ApiResponse.success(ProductDetailResponse.from(productInfo));
     }
 }

--- a/apps/commerce-api/src/main/resources/application.yml
+++ b/apps/commerce-api/src/main/resources/application.yml
@@ -20,6 +20,7 @@ spring:
   config:
     import:
       - jpa.yml
+      - redis.yml
       - logging.yml
       - monitoring.yml
 

--- a/apps/commerce-api/src/test/java/com/loopers/application/product/ProductCacheRefresherTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/product/ProductCacheRefresherTest.java
@@ -1,0 +1,83 @@
+package com.loopers.application.product;
+
+import com.loopers.domain.product.Product;
+import com.loopers.domain.product.ProductCache;
+import com.loopers.domain.product.ProductChangedEvent;
+import com.loopers.domain.product.ProductRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Duration;
+import java.util.Optional;
+
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ProductCacheRefresherTest {
+
+    @Mock ProductCache productCache;
+    @Mock ProductRepository productRepository;
+
+    @InjectMocks ProductCacheRefresher sut;
+
+    @Test
+    @DisplayName("정상: evict 후 DB에서 다시 로드해서 put 한다")
+    void refresh_ok() {
+        // Arrange
+        Long productId = 10L;
+        Product p = mock(Product.class);
+        when(productRepository.findWithBrandById(productId)).thenReturn(Optional.of(p));
+        when(productCache.ttl()).thenReturn(Duration.ofMinutes(3));
+
+        // Act
+        sut.onProductChanged(new ProductChangedEvent(productId));
+
+        // Assert
+        InOrder inOrder = inOrder(productCache, productRepository, productCache);
+        inOrder.verify(productCache).evict(productId);
+        inOrder.verify(productRepository).findWithBrandById(productId);
+        inOrder.verify(productCache).put(productId, p, Duration.ofMinutes(3));
+        verifyNoMoreInteractions(productCache, productRepository);
+    }
+
+    @Test
+    @DisplayName("예외: DB에 없으면 put하지 않고 경고만 (evict는 수행)")
+    void refresh_notFound() {
+        // Arrange
+        Long productId = 20L;
+        when(productRepository.findWithBrandById(productId)).thenReturn(Optional.empty());
+
+        // Act
+        sut.onProductChanged(new ProductChangedEvent(productId));
+
+        // Assert
+        verify(productCache, times(1)).evict(productId);
+        verify(productRepository, times(1)).findWithBrandById(productId);
+        verify(productCache, never()).put(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("예외: put에서 에러가 나도 전체 흐름은 잡아먹지 않는다(경고 로그)")
+    void refresh_putThrows_but_swallowed() {
+        // Arrange
+        Long productId = 30L;
+        Product p = mock(Product.class);
+        when(productRepository.findWithBrandById(productId)).thenReturn(Optional.of(p));
+        when(productCache.ttl()).thenReturn(Duration.ofMinutes(3));
+        doThrow(new RuntimeException("redis down")).when(productCache).put(eq(productId), eq(p), any());
+
+        // Act
+        sut.onProductChanged(new ProductChangedEvent(productId));
+
+        // Assert
+        verify(productCache).evict(productId);
+        verify(productRepository).findWithBrandById(productId);
+        verify(productCache).put(eq(productId), eq(p), any());
+        // 예외를 밖으로 던지지 않음
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/application/product/ProductOptionCacheRefresherTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/product/ProductOptionCacheRefresherTest.java
@@ -1,0 +1,109 @@
+package com.loopers.application.product;
+
+import com.loopers.domain.product.ProductChangedEvent;
+import com.loopers.domain.product.ProductOption;
+import com.loopers.domain.product.ProductOptionCache;
+import com.loopers.domain.product.ProductOptionRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Duration;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ProductOptionCacheRefresherTest {
+
+    @Mock
+    ProductOptionCache productOptionCache;
+
+    @Mock
+    ProductOptionRepository productOptionRepository;
+
+    @InjectMocks
+    ProductOptionCacheRefresher sut;
+
+    @Nested
+    @DisplayName("onProductChanged")
+    class OnProductChanged {
+
+        @Test
+        @DisplayName("정상: evict → repo 조회 → put 순으로 캐시 갱신한다")
+        void refresh_ok() {
+            // Arrange
+            Long productId = 10L;
+            var event = new ProductChangedEvent(productId);
+
+            ProductOption opt1 = mock(ProductOption.class);
+            ProductOption opt2 = mock(ProductOption.class);
+            List<ProductOption> loaded = List.of(opt1, opt2);
+            Duration ttl = Duration.ofMinutes(3);
+
+            when(productOptionRepository.findByProductId(productId)).thenReturn(loaded);
+            when(productOptionCache.ttl()).thenReturn(ttl);
+
+            // Act & Assert (예외 발생 없이 수행)
+            assertThatCode(() -> sut.onProductChanged(event)).doesNotThrowAnyException();
+
+            // Verify: 호출 순서와 파라미터
+            InOrder inOrder = inOrder(productOptionCache, productOptionRepository);
+            inOrder.verify(productOptionCache).evict(productId);
+            inOrder.verify(productOptionRepository).findByProductId(productId);
+            inOrder.verify(productOptionCache).put(eq(productId), eq(loaded), eq(ttl));
+            verifyNoMoreInteractions(productOptionRepository, productOptionCache);
+        }
+
+        @Test
+        @DisplayName("빈 리스트여도 evict 후 빈 리스트를 TTL과 함께 캐싱한다")
+        void refresh_withEmptyList() {
+            // Arrange
+            Long productId = 20L;
+            var event = new ProductChangedEvent(productId);
+
+            List<ProductOption> loaded = List.of(); // 빈 리스트
+            Duration ttl = Duration.ofMinutes(3);
+
+            when(productOptionRepository.findByProductId(productId)).thenReturn(loaded);
+            when(productOptionCache.ttl()).thenReturn(ttl);
+
+            // Act & Assert
+            assertThatCode(() -> sut.onProductChanged(event)).doesNotThrowAnyException();
+
+            // Verify
+            InOrder inOrder = inOrder(productOptionCache, productOptionRepository);
+            inOrder.verify(productOptionCache).evict(productId);
+            inOrder.verify(productOptionRepository).findByProductId(productId);
+            inOrder.verify(productOptionCache).put(eq(productId), eq(loaded), eq(ttl));
+            verifyNoMoreInteractions(productOptionRepository, productOptionCache);
+        }
+
+        @Test
+        @DisplayName("repo 예외 발생 시 put은 호출하지 않고, 예외는 전파하지 않는다")
+        void refresh_repoThrows_noPut_andNoThrow() {
+            // Arrange
+            Long productId = 30L;
+            var event = new ProductChangedEvent(productId);
+
+            when(productOptionRepository.findByProductId(productId))
+                    .thenThrow(new RuntimeException("DB error"));
+
+            // Act & Assert: 내부 try-catch로 예외 전파 안 됨
+            assertThatCode(() -> sut.onProductChanged(event)).doesNotThrowAnyException();
+
+            // Verify: evict는 호출, put은 호출 안 됨
+            verify(productOptionCache, times(1)).evict(productId);
+            verify(productOptionRepository, times(1)).findByProductId(productId);
+            verify(productOptionCache, never()).put(anyLong(), anyList(), any());
+            verifyNoMoreInteractions(productOptionRepository, productOptionCache);
+        }
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/product/ProductOptionServiceTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/product/ProductOptionServiceTest.java
@@ -1,0 +1,104 @@
+package com.loopers.domain.product;
+
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ProductOptionServiceTest {
+
+    @Mock
+    ProductOptionRepository productOptionRepository;
+
+    @Mock
+    ProductOptionCache productOptionCache;
+
+    @InjectMocks
+    ProductOptionService sut;
+
+    @Test
+    @DisplayName("캐시 히트면 리포지토리를 호출하지 않는다")
+    void getProductOptionsByProductId_cacheHit() {
+        // Arrange
+        Long productId = 1L;
+        ProductOption option = mock(ProductOption.class);
+        when(productOptionCache.getOrLoad(eq(productId), any()))
+                .thenReturn(List.of(option));
+
+        // Act
+        List<ProductOption> result = sut.getProductOptionsByProductId(productId);
+
+        // Assert
+        assertThat(result).hasSize(1).contains(option);
+        verifyNoInteractions(productOptionRepository);
+    }
+
+    @Test
+    @DisplayName("캐시 미스 시 로더로 적재하고, 이후에는 캐시에서 가져온다")
+    void getProductOptionsByProductId_cacheMiss_thenHit() throws Exception {
+        // Arrange
+        Long productId = 2L;
+        ProductOption option = mock(ProductOption.class);
+        AtomicReference<List<ProductOption>> stored = new AtomicReference<>();
+
+        when(productOptionRepository.findByProductId(productId)).thenReturn(List.of(option));
+        when(productOptionCache.getOrLoad(eq(productId), any()))
+                .thenAnswer(invocation -> {
+                    @SuppressWarnings("unchecked")
+                    Callable<List<ProductOption>> loader = invocation.getArgument(1, Callable.class);
+                    if (stored.get() == null) { // 캐시 미스
+                        List<ProductOption> loaded = loader.call(); // repo 호출
+                        stored.set(loaded);
+                        return loaded;
+                    }
+                    return stored.get(); // 캐시 히트
+                });
+
+        // Act
+        List<ProductOption> first = sut.getProductOptionsByProductId(productId);
+        List<ProductOption> second = sut.getProductOptionsByProductId(productId);
+
+        // Assert
+        assertThat(first).hasSize(1).contains(option);
+        assertThat(second).hasSize(1).contains(option);
+        verify(productOptionRepository, times(1)).findByProductId(productId);
+
+        InOrder inOrder = inOrder(productOptionCache, productOptionRepository);
+        inOrder.verify(productOptionCache).getOrLoad(eq(productId), any());
+        inOrder.verify(productOptionRepository).findByProductId(productId);
+        inOrder.verify(productOptionCache).getOrLoad(eq(productId), any());
+        verifyNoMoreInteractions(productOptionRepository);
+    }
+
+    @Test
+    @DisplayName("빈 리스트면 예외(Product option not found)를 던진다")
+    void getProductOptionsByProductId_empty_throws() {
+        // Arrange
+        Long productId = 3L;
+        when(productOptionCache.getOrLoad(eq(productId), any()))
+                .thenReturn(List.of());
+
+        // Act & Assert
+        assertThatThrownBy(() -> sut.getProductOptionsByProductId(productId))
+                .isInstanceOf(CoreException.class)
+                .hasMessageContaining("상품을 찾을 수 없습니다")
+                .extracting("errorType")
+                .isEqualTo(ErrorType.PRODUCT_OPTION_NOT_FOUND);
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/product/ProductServiceTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/product/ProductServiceTest.java
@@ -1,0 +1,97 @@
+package com.loopers.domain.product;
+
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+import java.util.concurrent.Callable;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ProductServiceTest {
+
+    @Mock
+    ProductRepository productRepository;
+
+    @Mock
+    ProductCache productCache;
+
+    @InjectMocks
+    ProductService sut;
+
+    @Test
+    @DisplayName("캐시 히트 시, Repository는 호출되지 않는다.")
+    void getProductWithBrandById_whenCacheHit_thenNoRepositoryCall() {
+        // Arrange
+        Long id = 100L;
+        Product cached = mock(Product.class);
+        when(productCache.getOrLoad(eq(id), any())).thenReturn(cached);
+
+        // Act
+        Product result = sut.getProductWithBrandById(id);
+
+        // Assert
+        assertThat(result).isSameAs(cached);
+        verifyNoInteractions(productRepository);
+    }
+
+    @Test
+    @DisplayName("캐시 미스 시, Repository에서 조회하여 반환한다.")
+    void getProductWithBrandById_whenCacheMiss_thenLoadFromRepository() throws Exception {
+        // Arrange
+        Long id = 200L;
+        Product loaded = mock(Product.class);
+        when(productRepository.findWithBrandById(id)).thenReturn(Optional.of(loaded));
+        when(productCache.getOrLoad(eq(id), any()))
+                .thenAnswer(inv -> {
+                    @SuppressWarnings("unchecked")
+                    Callable<Product> loader = inv.getArgument(1);
+                    return loader.call();
+                });
+
+        // Act
+        Product result = sut.getProductWithBrandById(id);
+
+        // Assert
+        assertThat(result).isSameAs(loaded);
+        verify(productRepository, times(1)).findWithBrandById(id);
+    }
+
+    @Test
+    @DisplayName("캐시 미스 + Repository 조회 결과 없음 시, 예외를 던진다.")
+    void getProductWithBrandById_whenCacheMissAndNotFound_thenThrowException() {
+        // Arrange
+        Long id = 300L;
+        when(productRepository.findWithBrandById(id)).thenReturn(Optional.empty());
+        when(productCache.getOrLoad(eq(id), any()))
+                .thenAnswer(inv -> {
+                    @SuppressWarnings("unchecked")
+                    Callable<Product> loader = inv.getArgument(1);
+                    try {
+                        return loader.call();
+                    } catch (Exception e) {
+                        throw new CoreException(ErrorType.PRODUCT_NOT_FOUND, e.getMessage());
+                    }
+                });
+
+        // Act & Assert
+        assertThatThrownBy(() -> sut.getProductWithBrandById(id))
+                .isInstanceOf(CoreException.class)
+                .hasMessageContaining("존재하지 않는 상품 id")
+                .extracting("errorType")
+                .isEqualTo(ErrorType.PRODUCT_NOT_FOUND);
+
+        verify(productRepository, times(1)).findWithBrandById(id);
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/product/ProductServiceTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/product/ProductServiceTest.java
@@ -86,7 +86,6 @@ class ProductServiceTest {
         when(productRepository.findWithBrandById(id)).thenReturn(Optional.empty());
         when(productCache.getOrLoad(eq(id), any()))
                 .thenAnswer(inv -> {
-                    @SuppressWarnings("unchecked")
                     Callable<Product> loader = inv.getArgument(1);
                     try {
                         return loader.call();
@@ -127,11 +126,11 @@ class ProductServiceTest {
 
     @Test
     @DisplayName("기본 필터 + 1~3페이지 범위에서 캐시 미스면 로더로 DB 조회하여 반환하고, 그 결과가 캐시에 저장된다")
-    void usesCache_whenDefaultFilter_andPageInRange_cacheMiss_thenLoadAndReturn() throws Exception {
+    void usesCache_whenDefaultFilter_andPageInRange_cacheMiss_thenLoadAndReturn() {
         // Arrange
         ProductCriteria criteria = mock(ProductCriteria.class);
         when(criteria.isDefault()).thenReturn(true);
-        Pageable pageable = PageRequest.of(1, 20); // page=2
+        Pageable pageable = PageRequest.of(1, 20);
         Page<Product> loaded = new PageImpl<>(List.of(mock(Product.class)), pageable, 40);
 
         // 레포지토리 결과 설정
@@ -139,9 +138,8 @@ class ProductServiceTest {
 
         // 캐시 미스 → 첫 호출 시 loader.call() 실행, 이후엔 캐시 히트 시나리오 흉내
         AtomicReference<Page<Product>> stored = new AtomicReference<>();
-        when(productListCache.getOrLoad(eq(2), any()))
+        when(productListCache.getOrLoad(eq(1), any()))
                 .thenAnswer(inv -> {
-                    @SuppressWarnings("unchecked")
                     Callable<Page<Product>> loader = inv.getArgument(1);
                     if (stored.get() == null) {
                         Page<Product> firstLoad = loader.call(); // DB 조회
@@ -162,9 +160,9 @@ class ProductServiceTest {
         verify(productRepository, times(1)).findAllByCriteria(criteria, pageable);
 
         InOrder inOrder = inOrder(productListCache, productRepository);
-        inOrder.verify(productListCache).getOrLoad(eq(2), any());
+        inOrder.verify(productListCache).getOrLoad(eq(1), any());
         inOrder.verify(productRepository).findAllByCriteria(criteria, pageable);
-        inOrder.verify(productListCache).getOrLoad(eq(2), any());
+        inOrder.verify(productListCache).getOrLoad(eq(1), any());
         verifyNoMoreInteractions(productRepository);
     }
 

--- a/apps/commerce-api/src/test/java/com/loopers/domain/product/ProductServiceTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/product/ProductServiceTest.java
@@ -5,12 +5,19 @@ import com.loopers.support.error.ErrorType;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.Callable;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -26,6 +33,9 @@ class ProductServiceTest {
 
     @Mock
     ProductCache productCache;
+
+    @Mock
+    ProductListCache productListCache;
 
     @InjectMocks
     ProductService sut;
@@ -93,5 +103,117 @@ class ProductServiceTest {
                 .isEqualTo(ErrorType.PRODUCT_NOT_FOUND);
 
         verify(productRepository, times(1)).findWithBrandById(id);
+    }
+
+    @Test
+    @DisplayName("기본 필터 + 1~3페이지 범위면 캐시를 사용하고, 캐시 히트 시 레포지토리를 호출하지 않는다")
+    void usesCache_whenDefaultFilter_andPageInRange_cacheHit() {
+        // Arrange
+        ProductCriteria criteria = mock(ProductCriteria.class);
+        when(criteria.isDefault()).thenReturn(true);
+        Pageable pageable = PageRequest.of(0, 20);
+        Page<Product> cached = new PageImpl<>(List.of(mock(Product.class)), pageable, 100);
+
+        when(productListCache.getOrLoad(eq(0), any())).thenReturn(cached);
+
+        // Act
+        Page<Product> result = sut.searchByConditionWithPaging(criteria, pageable);
+
+        // Assert
+        assertThat(result).isSameAs(cached);
+        verify(productRepository, never()).findAllByCriteria(any(), any());
+        verify(productListCache, times(0)).getOrLoad(eq(0), any());
+    }
+
+    @Test
+    @DisplayName("기본 필터 + 1~3페이지 범위에서 캐시 미스면 로더로 DB 조회하여 반환하고, 그 결과가 캐시에 저장된다")
+    void usesCache_whenDefaultFilter_andPageInRange_cacheMiss_thenLoadAndReturn() throws Exception {
+        // Arrange
+        ProductCriteria criteria = mock(ProductCriteria.class);
+        when(criteria.isDefault()).thenReturn(true);
+        Pageable pageable = PageRequest.of(1, 20); // page=2
+        Page<Product> loaded = new PageImpl<>(List.of(mock(Product.class)), pageable, 40);
+
+        // 레포지토리 결과 설정
+        when(productRepository.findAllByCriteria(criteria, pageable)).thenReturn(loaded);
+
+        // 캐시 미스 → 첫 호출 시 loader.call() 실행, 이후엔 캐시 히트 시나리오 흉내
+        AtomicReference<Page<Product>> stored = new AtomicReference<>();
+        when(productListCache.getOrLoad(eq(2), any()))
+                .thenAnswer(inv -> {
+                    @SuppressWarnings("unchecked")
+                    Callable<Page<Product>> loader = inv.getArgument(1);
+                    if (stored.get() == null) {
+                        Page<Product> firstLoad = loader.call(); // DB 조회
+                        stored.set(firstLoad);                   // 캐시에 저장되었다고 가정
+                        return firstLoad;
+                    }
+                    return stored.get(); // 두 번째부턴 캐시 히트
+                });
+
+        // Act
+        Page<Product> first = sut.searchByConditionWithPaging(criteria, pageable);
+        Page<Product> second = sut.searchByConditionWithPaging(criteria, pageable);
+
+        // Assert
+        assertThat(first).isSameAs(loaded);
+        assertThat(second).isSameAs(loaded);
+
+        verify(productRepository, times(1)).findAllByCriteria(criteria, pageable);
+
+        InOrder inOrder = inOrder(productListCache, productRepository);
+        inOrder.verify(productListCache).getOrLoad(eq(2), any());
+        inOrder.verify(productRepository).findAllByCriteria(criteria, pageable);
+        inOrder.verify(productListCache).getOrLoad(eq(2), any());
+        verifyNoMoreInteractions(productRepository);
+    }
+
+    @Test
+    @DisplayName("기본 필터가 아니면 캐시를 건너뛰고 바로 DB를 조회한다")
+    void bypassCache_whenNotDefaultFilter() {
+        // Arrange
+        ProductCriteria criteria = mock(ProductCriteria.class);
+        when(criteria.isDefault()).thenReturn(false);
+        Pageable pageable = PageRequest.of(1, 20);
+        Page<Product> db = new PageImpl<>(List.of(mock(Product.class)), pageable, 10);
+
+        when(productRepository.findAllByCriteria(criteria, pageable)).thenReturn(db);
+
+        // Act
+        Page<Product> result = sut.searchByConditionWithPaging(criteria, pageable);
+
+        // Assert
+        assertThat(result).isSameAs(db);
+        verify(productRepository, times(1)).findAllByCriteria(criteria, pageable);
+        verifyNoInteractions(productListCache);
+    }
+
+    @Test
+    @DisplayName("페이지가 캐싱 범위를 벗어나면(0페이지 또는 4페이지 이상) 캐시를 건너뛰고 DB를 조회한다")
+    void bypassCache_whenPageOutOfRange() {
+        // Arrange
+        ProductCriteria criteria = mock(ProductCriteria.class);
+        when(criteria.isDefault()).thenReturn(true);
+
+        // page=0 (서비스 로직상 1~3만 캐시)
+        Pageable p0 = PageRequest.of(0, 20);
+        Page<Product> db0 = new PageImpl<>(List.of(mock(Product.class)), p0, 10);
+        when(productRepository.findAllByCriteria(criteria, p0)).thenReturn(db0);
+
+        // page=4
+        Pageable p4 = PageRequest.of(3, 20);
+        Page<Product> db4 = new PageImpl<>(List.of(mock(Product.class)), p4, 10);
+        when(productRepository.findAllByCriteria(criteria, p4)).thenReturn(db4);
+
+        // Act
+        Page<Product> r0 = sut.searchByConditionWithPaging(criteria, p0);
+        Page<Product> r4 = sut.searchByConditionWithPaging(criteria, p4);
+
+        // Assert
+        assertThat(r0).isSameAs(db0);
+        assertThat(r4).isSameAs(db4);
+        verify(productRepository, times(1)).findAllByCriteria(criteria, p0);
+        verify(productRepository, times(1)).findAllByCriteria(criteria, p4);
+        verifyNoInteractions(productListCache);
     }
 }

--- a/apps/commerce-api/src/test/java/com/loopers/support/E2ETestSupport.java
+++ b/apps/commerce-api/src/test/java/com/loopers/support/E2ETestSupport.java
@@ -1,6 +1,7 @@
 package com.loopers.support;
 
 import com.loopers.utils.DatabaseCleanUp;
+import com.loopers.utils.RedisCleanUp;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -14,9 +15,13 @@ public abstract class E2ETestSupport {
     @Autowired
     private DatabaseCleanUp databaseCleanUp;
 
+    @Autowired
+    private RedisCleanUp redisCleanUp;
+
     @BeforeEach
     void tearDown() {
         databaseCleanUp.truncateAllTables();
+        redisCleanUp.clearAll();
     }
 
 }

--- a/apps/commerce-api/src/test/java/com/loopers/support/IntegrationTestSupport.java
+++ b/apps/commerce-api/src/test/java/com/loopers/support/IntegrationTestSupport.java
@@ -1,6 +1,7 @@
 package com.loopers.support;
 
 import com.loopers.utils.DatabaseCleanUp;
+import com.loopers.utils.RedisCleanUp;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -11,9 +12,13 @@ public abstract class IntegrationTestSupport {
     @Autowired
     private DatabaseCleanUp databaseCleanUp;
 
+    @Autowired
+    private RedisCleanUp redisCleanUp;
+
     @BeforeEach
     void tearDown() {
         databaseCleanUp.truncateAllTables();
+        redisCleanUp.clearAll();
     }
 
 }

--- a/data/dummy/product-list-bench.k6.js
+++ b/data/dummy/product-list-bench.k6.js
@@ -1,6 +1,6 @@
 import http from 'k6/http';
-import { check, sleep } from 'k6';
-import { Trend, Counter } from 'k6/metrics';
+import {check, sleep} from 'k6';
+import {Counter, Trend} from 'k6/metrics';
 
 // ===== ENV
 const BASE = __ENV.BASE_URL || 'http://localhost:8080';

--- a/docker/infra-compose.yml
+++ b/docker/infra-compose.yml
@@ -14,8 +14,22 @@ services:
     volumes:
       - mysql-8-data:/var/lib/mysql
 
+  redis:
+    image: redis:7.2
+    ports:
+      - "6379:6379"
+    command: [ "redis-server", "--appendonly", "yes" ] # AOF로 영속화
+    volumes:
+      - redis-data:/data
+    healthcheck:
+      test: [ "CMD", "redis-cli", "ping" ]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+
 volumes:
   mysql-8-data:
+  redis-data:
 
 networks:
   default:

--- a/modules/redis/build.gradle.kts
+++ b/modules/redis/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     `java-library`
+    `java-test-fixtures`
 }
 
 dependencies {

--- a/modules/redis/build.gradle.kts
+++ b/modules/redis/build.gradle.kts
@@ -1,5 +1,8 @@
+plugins {
+    `java-library`
+}
+
 dependencies {
     // Redis
-    implementation("org.springframework.boot:spring-boot-starter-data-redis")
-    implementation("com.fasterxml.jackson.core:jackson-databind")
+    api("org.springframework.boot:spring-boot-starter-data-redis")
 }

--- a/modules/redis/build.gradle.kts
+++ b/modules/redis/build.gradle.kts
@@ -1,0 +1,5 @@
+dependencies {
+    // Redis
+    implementation("org.springframework.boot:spring-boot-starter-data-redis")
+    implementation("com.fasterxml.jackson.core:jackson-databind")
+}

--- a/modules/redis/src/main/java/com/loopers/config/redis/RedisConfig.java
+++ b/modules/redis/src/main/java/com/loopers/config/redis/RedisConfig.java
@@ -1,24 +1,12 @@
 package com.loopers.config.redis;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.data.redis.cache.RedisCacheConfiguration;
-import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
-import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
-import org.springframework.data.redis.serializer.RedisSerializationContext;
-import org.springframework.data.redis.serializer.StringRedisSerializer;
-
-import java.time.Duration;
-import java.util.HashMap;
-import java.util.Map;
+import org.springframework.data.redis.core.StringRedisTemplate;
 
 @Configuration
 @EnableCaching
@@ -32,49 +20,10 @@ public class RedisConfig {
     }
 
     @Bean
-    public ObjectMapper objectMapper() {
-        return new ObjectMapper()
-                .findAndRegisterModules()
-                .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
-    }
-
-    @Bean
-    public RedisTemplate<String, Object> redisTemplate(
-            RedisConnectionFactory connectionFactory,
-            ObjectMapper objectMapper
-    ) {
-        RedisTemplate<String, Object> template = new RedisTemplate<>();
-        template.setConnectionFactory(connectionFactory);
-
-        StringRedisSerializer keySerializer = new StringRedisSerializer();
-        GenericJackson2JsonRedisSerializer valueSerializer =
-                new GenericJackson2JsonRedisSerializer(objectMapper);
-
-        template.setKeySerializer(keySerializer);
-        template.setValueSerializer(valueSerializer);
-        template.setHashKeySerializer(keySerializer);
-        template.setHashValueSerializer(valueSerializer);
-
-        template.afterPropertiesSet();
-        return template;
-    }
-
-    @Bean
-    public CacheManager cacheManager(ObjectMapper objectMapper, RedisConnectionFactory cf) {
-        GenericJackson2JsonRedisSerializer serializer =
-                new GenericJackson2JsonRedisSerializer(objectMapper);
-
-        RedisCacheConfiguration base = RedisCacheConfiguration.defaultCacheConfig()
-                .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
-                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(serializer))
-                .disableCachingNullValues();
-
-        Map<String, RedisCacheConfiguration> conf = new HashMap<>();
-        conf.put("product:detail", base.entryTtl(Duration.ofMinutes(3)));
-
-        return RedisCacheManager.builder(cf)
-                .cacheDefaults(base)
-                .withInitialCacheConfigurations(conf)
-                .build();
+    public StringRedisTemplate stringRedisTemplate(RedisConnectionFactory cf) {
+        StringRedisTemplate t = new StringRedisTemplate();
+        t.setConnectionFactory(cf);
+        t.afterPropertiesSet();
+        return t;
     }
 }

--- a/modules/redis/src/main/java/com/loopers/config/redis/RedisConfig.java
+++ b/modules/redis/src/main/java/com/loopers/config/redis/RedisConfig.java
@@ -1,0 +1,80 @@
+package com.loopers.config.redis;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+@EnableCaching
+public class RedisConfig {
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory(
+            @Value("${spring.data.redis.host}") String host,
+            @Value("${spring.data.redis.port}") int port
+    ) {
+        return new LettuceConnectionFactory(host, port);
+    }
+
+    @Bean
+    public ObjectMapper objectMapper() {
+        return new ObjectMapper()
+                .findAndRegisterModules()
+                .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(
+            RedisConnectionFactory connectionFactory,
+            ObjectMapper objectMapper
+    ) {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+
+        StringRedisSerializer keySerializer = new StringRedisSerializer();
+        GenericJackson2JsonRedisSerializer valueSerializer =
+                new GenericJackson2JsonRedisSerializer(objectMapper);
+
+        template.setKeySerializer(keySerializer);
+        template.setValueSerializer(valueSerializer);
+        template.setHashKeySerializer(keySerializer);
+        template.setHashValueSerializer(valueSerializer);
+
+        template.afterPropertiesSet();
+        return template;
+    }
+
+    @Bean
+    public CacheManager cacheManager(ObjectMapper objectMapper, RedisConnectionFactory cf) {
+        GenericJackson2JsonRedisSerializer serializer =
+                new GenericJackson2JsonRedisSerializer(objectMapper);
+
+        RedisCacheConfiguration base = RedisCacheConfiguration.defaultCacheConfig()
+                .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
+                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(serializer))
+                .disableCachingNullValues();
+
+        Map<String, RedisCacheConfiguration> conf = new HashMap<>();
+        conf.put("product:detail", base.entryTtl(Duration.ofMinutes(3)));
+
+        return RedisCacheManager.builder(cf)
+                .cacheDefaults(base)
+                .withInitialCacheConfigurations(conf)
+                .build();
+    }
+}

--- a/modules/redis/src/main/resources/redis.yml
+++ b/modules/redis/src/main/resources/redis.yml
@@ -1,0 +1,91 @@
+spring:
+  cache:
+    type: redis
+    redis:
+      time-to-live: 180000
+      use-key-prefix: true
+      key-prefix: loopers
+  data:
+    redis:
+      host: ${REDIS_HOST:redis}
+      port: ${REDIS_PORT:6379}
+      password: ${REDIS_PASSWORD:}
+      timeout: 2000
+      lettuce:
+        pool:
+          max-active: 16
+          max-idle: 8
+          min-idle: 2
+          max-wait: 1000ms
+
+---
+spring.config.activate.on-profile: local
+
+spring:
+  data:
+    redis:
+      host: localhost
+      port: 6379
+      password:
+
+  cache:
+    redis:
+      time-to-live: 60000
+
+---
+spring.config.activate.on-profile: test
+
+spring:
+  cache:
+    type: none
+  data:
+    redis:
+      host: localhost
+      port: 6379
+      password:
+
+---
+spring.config.activate.on-profile: dev
+
+spring:
+  data:
+    redis:
+      host: ${REDIS_HOST:redis}
+      port: ${REDIS_PORT:6379}
+      password: ${REDIS_PASSWORD:}
+  cache:
+    redis:
+      time-to-live: 180000
+
+---
+spring.config.activate.on-profile: qa
+
+spring:
+  data:
+    redis:
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT:6379}
+      password: ${REDIS_PASSWORD}
+  cache:
+    redis:
+      time-to-live: 300000
+
+---
+spring.config.activate.on-profile: prd
+
+spring:
+  data:
+    redis:
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT:6379}
+      password: ${REDIS_PASSWORD}
+      timeout: 3000
+      lettuce:
+        pool:
+          max-active: 64
+          max-idle: 32
+          min-idle: 8
+          max-wait: 2000ms
+  cache:
+    redis:
+      time-to-live: 600000

--- a/modules/redis/src/testFixtures/java/com/loopers/utils/RedisCleanUp.java
+++ b/modules/redis/src/testFixtures/java/com/loopers/utils/RedisCleanUp.java
@@ -1,0 +1,22 @@
+package com.loopers.utils;
+
+import org.springframework.data.redis.core.RedisCallback;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+public class RedisCleanUp {
+
+    private final StringRedisTemplate redisTemplate;
+
+    public RedisCleanUp(StringRedisTemplate redisTemplate) {
+        this.redisTemplate = redisTemplate;
+    }
+
+    public void clearAll() {
+        redisTemplate.execute((RedisCallback<Void>) connection -> {
+            connection.serverCommands().flushAll();
+            return null;
+        });
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -3,6 +3,7 @@ rootProject.name = "loopers-commerce"
 include(
     ":apps:commerce-api",
     ":modules:jpa",
+    ":modules:redis",
     ":supports:jackson",
     ":supports:logging",
     ":supports:monitoring",


### PR DESCRIPTION
## 📌 Summary
상품 목록 조회 시 발생하던 불필요한 Filesort를 제거하고 조회 성능을 최적화했습니다.  
실제 서비스 시나리오(브랜드·카테고리·정렬 조건)에 맞춰 복합 인덱스를 설계하고,  
EXPLAIN 비교 및 k6 부하 테스트로 개선 효과를 검증했습니다.  
또한, Redis 기반 캐싱 구조를 Port-Adapter 패턴으로 구성하여 공통 로직을 일관되게 적용했습니다.

---

## 💬 Review Points
1. **인덱스 설계 근거**
    - 단일 컬럼 인덱스 대신, 정렬 컬럼까지 포함한 복합 인덱스를 설계.
    - 4가지 주요 조회 패턴(Use Case)에 맞춘 인덱스 생성.
2. **커버링 인덱스 적용 고민**
    - 모든 컬럼을 포함한 커버링 인덱스는 select 컬럼 수가 많아 부분 적용으로 결정.
3. **캐시 구조 개선**
    - `RedisGenericCachePort`를 공통 구현체로 두고, 개별 캐시(예: `ProductCache`)는 키 생성·TTL 정의에만 집중.
    - 락 처리, 직렬화/역직렬화, 빈 값 정책을 한 번만 구현하여 중복 제거.
4. **성능 측정**
    - UC1~UC4 모두 Filesort 제거.
    - k6 테스트 기준 평균·p95 응답시간이 전반적으로 소폭 감소.
5. **확인 요청**
    - 운영 DB에서도 동일하게 인덱스 플랜과 캐싱 동작이 재현되는지 확인 필요.

---

## ✅ Checklist
- [x] 복합 인덱스 4종 생성
- [x] 유즈케이스별 EXPLAIN 전/후 성능 비교
- [x] k6 부하 테스트 실행 및 결과 반영
- [x] RedisGenericCachePort 기반 캐싱 구조 적용

---

## 📎 References

### 1) 인덱스 설계
```sql
-- UC1: 브랜드 + 카테고리 + 좋아요순 + 최신순
CREATE INDEX idx_brand_category_like_id
  ON products (brand_id, product_category, like_count DESC, id DESC);

-- UC2: 브랜드 + 카테고리 + 가격순 + 최신순
CREATE INDEX idx_brand_category_price_id
  ON products (brand_id, product_category, basic_price ASC, id DESC);

-- UC3: 브랜드 + 좋아요순 + 최신순
CREATE INDEX idx_brand_like_id
  ON products (brand_id, like_count DESC, id DESC);

-- UC4: 브랜드 + 가격순 + 최신순
CREATE INDEX idx_brand_price_id
  ON products (brand_id, basic_price ASC, id DESC);
```
### 2) 유즈케이스별 쿼리 & 성능 비교

| UC  | 쿼리 | Before – key / rows / Extra | After – key / rows / Extra | 개선 포인트 |
|---|---|---|---|---|
| UC1 | WHERE brand_id = ? AND product_category = 'CLOTHING' ORDER BY like_count DESC, id DESC LIMIT 20 | idx_brand_price_id / 200 / Using where; Using filesort | idx_brand_like_id / 200 / Using where | Filesort 제거 → 인덱스 순차 스캔 활용 |
| UC2 | WHERE brand_id = ? AND product_category = 'CLOTHING' ORDER BY basic_price, id DESC LIMIT 20 | idx_brand_price_id / 200 / Using where; Using filesort | idx_brand_price_id / 200 / Using where | Filesort 제거 |
| UC3 | WHERE brand_id = ? ORDER BY like_count DESC, id DESC LIMIT 20 | idx_brand_price_id / 200 / Using filesort | idx_brand_like_id / 200 / *(null)* | Filesort 제거, 순차 인덱스 스캔 |
| UC4 | WHERE brand_id = ? ORDER BY basic_price, id DESC LIMIT 20 | idx_brand_price_id / 200 / Using filesort | idx_brand_price_id / 200 / *(null)* | Filesort 제거, 순차 인덱스 스캔 |

### 3) k6 성능 결과 (Before → After)

| Metric (Scenario) | Before Avg | After Avg | Before p(95) | After p(95) | Change Avg | Change p(95) |
|-------------------|-----------:|----------:|-------------:|------------:|-----------:|-------------:|
| UC1 Duration      | 16.5883 ms | 16.4664 ms | 25.2784 ms | 24.9821 ms | **-0.1219 ms** | **-0.2963 ms** |
| UC2 Duration      | 16.4360 ms | 16.2733 ms | 26.2548 ms | 24.4146 ms | **-0.1627 ms** | **-1.8402 ms** |
| UC3 Duration      | 16.5549 ms | 16.4149 ms | 26.1010 ms | 25.2722 ms | **-0.1399 ms** | **-0.8288 ms** |
| UC4 Duration      | 16.0937 ms | 16.4854 ms | 25.8263 ms | 25.1156 ms | **+0.3918 ms** | **-0.7108 ms** |
| 전체 HTTP Req     | 16.4182 ms | 16.4100 ms | 25.9909 ms | 25.0012 ms | **-0.0082 ms** | **-0.9897 ms** |

## 4) 개선 요약
- UC1/UC3: brand_id, like_count DESC, id DESC 복합 인덱스로 **정렬 시 Filesort 제거** → 인덱스 순차 스캔.
- UC2/UC4: brand_id, basic_price ASC, id DESC로 **가격 정렬 최적화** → Filesort 제거.